### PR TITLE
OpenStreetMap.BlackAndWhite_replaced_for_OpenStreetMap

### DIFF
--- a/inst/SpatialEpiApp/server.R
+++ b/inst/SpatialEpiApp/server.R
@@ -1196,7 +1196,7 @@ rv$colores<-pal(values)
 ids<-as.integer(as.vector(mapFiltered@data[, "id"]))
 
 leaflet(mapFiltered) %>%
-        addProviderTiles("OpenStreetMap.BlackAndWhite", options = providerTileOptions(noWrap = TRUE))  %>%
+        addProviderTiles("OpenStreetMap", options = providerTileOptions(noWrap = TRUE))  %>%
         addPolygons(data=mapFiltered, layerId=ids, fillColor = ~pal(values), smoothFactor = 0.2, fillOpacity = 0.9, stroke=FALSE)  %>%
   leaflet::addLegend("bottomright", pal = pal, values = values, title = input$vblePintar, labFormat = labelFormat(prefix = ""), opacity = 1)
 


### PR DESCRIPTION
"Interactive" tab is not working (not even with the sample data).

Looks like OpenStreetMap.BlackAndWhite is not a leaflet provider of tiles anymore: see https://github.com/leaflet-extras/leaflet-providers/issues/316

I replaced OpenStreetMap.BlackAndWhite for OpenStreetMap and now the "Interactive" tab works perfectly.